### PR TITLE
Allocate strings in the correct heap

### DIFF
--- a/lib/stringlib.c
+++ b/lib/stringlib.c
@@ -314,7 +314,9 @@ gchar * prepare_string(const gchar * input, gboolean delintify, gboolean do_curl
                 {
                     if(do_curl_escape)
                     {
-                        result = curl_easy_escape(NULL,no_lint,0);
+                        char* m_result = curl_easy_escape(NULL,no_lint,0);
+                        result = g_strdup(m_result);
+                        curl_free(m_result);
                     }
                     else
                     {


### PR DESCRIPTION
Hello,

While testing the latest glyr with gmpc, it segfaulted in `prepare_string`. I applied this changes and it works fine now :

`curl_easy_escape` returns a string allocated within libcurl. For consistency, it
should be put in a glib-managed buffer to avoid a segfault at a later `g_free`.

This patch copies the temporary buffer into a glib buffer.

Thanks !
