### PR TITLE
Fix some typos

### DIFF
--- a/src/glyrc/glyrc.c
+++ b/src/glyrc/glyrc.c
@@ -317,7 +317,7 @@ void help_short (GlyrQuery * s)
             IN"    glyrc cover --artist SomeBand --album SomeAlbum\n"
             IN"   \n"
             IN"  DB:\n\n"
-            IN"    glyrc lyrics -a A -b B --cache /tmp # Write found items to cache; create it if not existant\n"
+            IN"    glyrc lyrics -a A -b B --cache /tmp # Write found items to cache; create it if not existent\n"
             IN"    glyrc cache list --cache /tmp # List all in the cache\n"
             IN"    glyrc cache delete cover -a Equilibrium -b Sagas --cache /tmp # Delete artist/album\n"
             IN"    glyrc cache select lyrics -a Knorkator -t 'A' -n 2 --cache /tmp # Search for two items in cache and print them\n"

--- a/src/glyrc/glyrc.c
+++ b/src/glyrc/glyrc.c
@@ -306,7 +306,7 @@ void help_short (GlyrQuery * s)
             IN"-Y --no-color            Prints no colored output\n"
             IN"-s --musictree-path <p>  <p> is a path to your music directory. Glyr might fetch things like folger.jpg from there;\n"
             IN"-j --callback            Command: Set a bash command to be executed when a item is finished downloading;\n"
-            IN"                                  All escapes mentioned in --write are supported too, and additonally:\n"
+            IN"                                  All escapes mentioned in --write are supported too, and additionally:\n"
             IN"                                    * path : The path were the item was written to.\n"
             "\nDATABASE OPTIONS\n"
             IN"-c --cache <folder>      Creates or opens an existing cache at <folder>/metadata.db and lookups data from there.\n"


### PR DESCRIPTION
Hi,

While preparing the debian package for 1.0.9 I noticed [a few warnings](https://lintian.debian.org/full/pkg-multimedia-maintainers@lists.alioth.debian.org.html#glyr_1.0.8-2) related to two typos.

Here's a fix!

Thanks