### PR TITLE
Move shebang and encoding lines at the start of the file

### DIFF
--- a/spec/provider/runner.py
+++ b/spec/provider/runner.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+# encoding: utf-8
 #################################################################
 # This file is part of glyr
 # + a command-line tool and library to download various sort of music related metadata.
@@ -17,8 +19,6 @@
 # You should have received a copy of the GNU General Public License
 # along with glyr. If not, see <http://www.gnu.org/licenses/>.
 #################################################################
-#!/usr/bin/env python
-# encoding: utf-8
 
 import os
 import sys

--- a/spec/provider/tests/artistbio.py
+++ b/spec/provider/tests/artistbio.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+# encoding: utf-8
 #################################################################
 # This file is part of glyr
 # + a command-line tool and library to download various sort of music related metadata.
@@ -17,8 +19,6 @@
 # You should have received a copy of the GNU General Public License
 # along with glyr. If not, see <http://www.gnu.org/licenses/>.
 #################################################################
-#!/usr/bin/env python
-# encoding: utf-8
 
 from tests.__common__ import *
 

--- a/spec/provider/tests/artistphoto.py
+++ b/spec/provider/tests/artistphoto.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+# encoding: utf-8
 #################################################################
 # This file is part of glyr
 # + a command-line tool and library to download various sort of music related metadata.
@@ -17,8 +19,6 @@
 # You should have received a copy of the GNU General Public License
 # along with glyr. If not, see <http://www.gnu.org/licenses/>.
 #################################################################
-#!/usr/bin/env python
-# encoding: utf-8
 
 from tests.__common__ import *
 


### PR DESCRIPTION
Tests were failing because the encoding line wasn't first or second in the file.
```
$ python runner.py 
('Error while loading', 'tests.artistbio', 'Traceback (most recent call last):  File "runner.py", line 87, in main
 test_modules.append((full_path, __import__(full_path, fromlist=[\'TESTCASES\'])))
  File "/glyr/spec/provider/tests/artistbio.py", line 37
SyntaxError: Non-ASCII character \'\\xc3\' in file /glyr/spec/provider/tests/artistbio.py on line 37, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details
')

```