### PR TITLE
Add Dockerfile to easily compile and use glyrc inside a docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM ubuntu:16.04
+
+RUN apt-get update && apt-get install -y g++ gcc cmake pkg-config git curl libcurl3-dev sqlite3 libglib2.0-dev libsqlite3-dev
+
+WORKDIR /opt
+
+RUN git clone https://github.com/sahib/glyr.git
+
+WORKDIR /opt/glyr
+
+RUN mkdir build
+
+WORKDIR /opt/glyr/build
+
+RUN cmake .. && make
+
+RUN apt-get -y purge g++ gcc cmake pkg-config git && apt-get clean && rm -rf /var/lib/apt
+
+CMD /opt/glyr/build/bin/glyrc

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,6 @@ RUN cmake .. && make
 
 RUN apt-get -y purge g++ gcc cmake pkg-config git && apt-get clean && rm -rf /var/lib/apt
 
+RUN ln -s /opt/glyr/build/bin/glyrc /usr/bin/
+
 CMD /opt/glyr/build/bin/glyrc

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker build -t glyrc .


### PR DESCRIPTION
This commit adds a Dockerfile to easily compile glyrc as a Docker container and allow the user to use docker inside that container.

Usage consists of:

1) compiling docker image
$ ./build-docker.sh

2) Executing glyrc inside docker:
$ docker run -it --rm glyrc glyrc lyrics --artist "blind guardian" --title "bright eyes"