### PR TITLE
CMakeLists.txt: fix version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ ENDIF()
 # ------------------------------------------------
 SET(GLYR_VERSION_MAJOR "1")
 SET(GLYR_VERSION_MINOR "0")
-SET(GLYR_VERSION_MICRO "9")
+SET(GLYR_VERSION_MICRO "10")
 SET(GLYR_VERSION_NAME  "Raving Raven")
 # ------------------------------------------------
 


### PR DESCRIPTION
This avoids e.g. the pkg-config file installed having the wrong version.

It must be updated on new tags/releases (just before tagging).

Signed-off-by: Sam James <sam@gentoo.org>